### PR TITLE
Removed nuget reference for Material.Forms

### DIFF
--- a/src/Material.Application/Infrastructure/IDialogService.cs
+++ b/src/Material.Application/Infrastructure/IDialogService.cs
@@ -1,65 +1,65 @@
-using System;
-using System.Threading.Tasks;
-using Material.Application.Routing;
-using MaterialForms;
+//using System;
+//using System.Threading.Tasks;
+//using Material.Application.Routing;
+//using MaterialForms;
 
-namespace Material.Application.Infrastructure
-{
-    public interface IDialogService
-    {
-        DialogSession ShowTrackedDialog(MaterialDialog dialog, double width);
+//namespace Material.Application.Infrastructure
+//{
+//    public interface IDialogService
+//    {
+//        DialogSession ShowTrackedDialog(MaterialDialog dialog, double width);
 
-        void CloseDialogs();
-    }
+//        void CloseDialogs();
+//    }
 
 
-    public static class DialogServiceExtensions
-    {
-        public static async Task Alert(this IDialogService dialogService, string message)
-        {
-            try
-            {
-                await dialogService.ShowTrackedDialog(DialogFactory.Alert(message), Route.SmallDialog).Task;
-            }
-            catch
-            {
-                // ignored
-            }
-        }
+//    public static class DialogServiceExtensions
+//    {
+//        public static async Task Alert(this IDialogService dialogService, string message)
+//        {
+//            try
+//            {
+//                await dialogService.ShowTrackedDialog(DialogFactory.Alert(message), Route.SmallDialog).Task;
+//            }
+//            catch
+//            {
+//                // ignored
+//            }
+//        }
 
-        public static Task<bool?> ShowDialog(this IDialogService dialogService, MaterialDialog dialog)
-            => ShowDialog(dialogService, dialog, Route.SmallDialog);
+//        public static Task<bool?> ShowDialog(this IDialogService dialogService, MaterialDialog dialog)
+//            => ShowDialog(dialogService, dialog, Route.SmallDialog);
 
-        public static Task<bool?> ShowDialog(this IDialogService dialogService, MaterialDialog dialog, double width)
-            => dialogService.ShowTrackedDialog(dialog, width).Task;
+//        public static Task<bool?> ShowDialog(this IDialogService dialogService, MaterialDialog dialog, double width)
+//            => dialogService.ShowTrackedDialog(dialog, width).Task;
 
-        public static async Task RunTask(this IDialogService dialogService, Func<Task> task, string message)
-        {
-            var dialog = new MaterialDialog
-            {
-                Message = message,
-                PositiveAction = null,
-                NegativeAction = null,
-                Form = new MaterialForm
-                {
-                    new ProgressSchema
-                    {
-                        IsIndeterminate = true,
-                        ShowPercentage = false
-                    }
-                }
-            };
+//        public static async Task RunTask(this IDialogService dialogService, Func<Task> task, string message)
+//        {
+//            var dialog = new MaterialDialog
+//            {
+//                Message = message,
+//                PositiveAction = null,
+//                NegativeAction = null,
+//                Form = new MaterialForm
+//                {
+//                    new ProgressSchema
+//                    {
+//                        IsIndeterminate = true,
+//                        ShowPercentage = false
+//                    }
+//                }
+//            };
 
-            Session session = null;
-            try
-            {
-                session = dialogService.ShowTrackedDialog(dialog, Route.LargeDialog);
-                await Task.Run(task);
-            }
-            finally
-            {
-                session?.Close(true);
-            }
-        }
-    }
-}
+//            Session session = null;
+//            try
+//            {
+//                session = dialogService.ShowTrackedDialog(dialog, Route.LargeDialog);
+//                await Task.Run(task);
+//            }
+//            finally
+//            {
+//                session?.Close(true);
+//            }
+//        }
+//    }
+//}

--- a/src/Material.Application/Infrastructure/Internal/DefaultAppModule.cs
+++ b/src/Material.Application/Infrastructure/Internal/DefaultAppModule.cs
@@ -58,8 +58,8 @@ namespace Material.Application.Infrastructure
                 .InSingletonScope()
                 .WithConstructorArgument("snackbarMessageQueue", appController.SnackbarMessageQueue);
 
-            Bind<IDialogService>()
-                .To<DialogHostService>();
+            //Bind<IDialogService>()
+            //    .To<DialogHostService>();
 
             Bind<IFilePicker>()
                 .To<DialogFilePicker>();

--- a/src/Material.Application/Infrastructure/Internal/DialogHostService.cs
+++ b/src/Material.Application/Infrastructure/Internal/DialogHostService.cs
@@ -1,51 +1,51 @@
-using System;
-using Material.Application.Helpers;
-using MaterialForms;
+//using System;
+//using Material.Application.Helpers;
+//using MaterialForms;
 
-namespace Material.Application.Infrastructure
-{
-    internal class DialogHostService : IDialogService
-    {
-        private readonly IMainWindowLocator windowLocator;
+//namespace Material.Application.Infrastructure
+//{
+//    internal class DialogHostService : IDialogService
+//    {
+//        private readonly IMainWindowLocator windowLocator;
 
-        public DialogHostService(IMainWindowLocator windowLocator)
-        {
-            this.windowLocator = windowLocator;
-        }
+//        public DialogHostService(IMainWindowLocator windowLocator)
+//        {
+//            this.windowLocator = windowLocator;
+//        }
 
-        public DialogSession ShowTrackedDialog(MaterialDialog dialog, double width)
-        {
-            var window = windowLocator.GetMainWindow();
-            if (window == null)
-            {
-                throw new InvalidOperationException(ErrorMessages.MainWindowNotFound);
-            }
+//        public DialogSession ShowTrackedDialog(MaterialDialog dialog, double width)
+//        {
+//            var window = windowLocator.GetMainWindow();
+//            if (window == null)
+//            {
+//                throw new InvalidOperationException(ErrorMessages.MainWindowNotFound);
+//            }
 
-            if (window is IDialogHostContainer hostContainer)
-            {
-                var dialogHost = hostContainer.GetRootDialog();
-                return dialog.ShowTracked(dialogHost.Identifier.ToString(), width);
-            }
+//            if (window is IDialogHostContainer hostContainer)
+//            {
+//                var dialogHost = hostContainer.GetRootDialog();
+//                return dialog.ShowTracked(dialogHost.Identifier.ToString(), width);
+//            }
 
-            throw new InvalidOperationException("Cannot display dialog in current window.");
-        }
+//            throw new InvalidOperationException("Cannot display dialog in current window.");
+//        }
 
-        public void CloseDialogs()
-        {
-            var window = windowLocator.GetMainWindow();
-            if (window == null)
-            {
-                return;
-            }
+//        public void CloseDialogs()
+//        {
+//            var window = windowLocator.GetMainWindow();
+//            if (window == null)
+//            {
+//                return;
+//            }
 
-            if (window is IDialogHostContainer hostContainer)
-            {
-                var dialogHost = hostContainer.GetRootDialog();
-                if (dialogHost.CheckAccess())
-                {
-                    dialogHost.IsOpen = false;
-                }
-            }
-        }
-    }
-}
+//            if (window is IDialogHostContainer hostContainer)
+//            {
+//                var dialogHost = hostContainer.GetRootDialog();
+//                if (dialogHost.CheckAccess())
+//                {
+//                    dialogHost.IsOpen = false;
+//                }
+//            }
+//        }
+//    }
+//}

--- a/src/Material.Application/Material.Application.csproj
+++ b/src/Material.Application/Material.Application.csproj
@@ -39,9 +39,6 @@
     <Reference Include="MaterialDesignThemes.Wpf, Version=2.3.0.823, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MaterialDesignThemes.2.3.0.823\lib\net45\MaterialDesignThemes.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="MaterialForms, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WpfMaterialForms.1.1.2\lib\net461\MaterialForms.dll</HintPath>
-    </Reference>
     <Reference Include="Ninject, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
     </Reference>

--- a/src/Material.Application/packages.config
+++ b/src/Material.Application/packages.config
@@ -4,5 +4,4 @@
   <package id="MaterialDesignColors" version="1.1.3" targetFramework="net461" />
   <package id="MaterialDesignThemes" version="2.3.0.823" targetFramework="net461" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net461" />
-  <package id="WpfMaterialForms" version="1.1.2" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
There is no reason whatsoever for a framework to be opinionated towards specific tools such as this one. It should provide the means to host dialogs and forms, what is shown in them is up to the consumer.

@redbaty we need to merge and publish this to nuget because I want to delete the dupe from material forms and use a nuget reference instead. Currently I can't do that because it creates a weird dependency graph.

Regarding dialogs a generic utility should be implemented that allows hosting content to the main window. The content can be a dynamic form, but we don't need to know that in compile time.